### PR TITLE
Use three samples instead of one

### DIFF
--- a/dns-speed.sh
+++ b/dns-speed.sh
@@ -14,20 +14,27 @@ touch $temp_file
 
 # Test the dns servers listed on the dns-list.txt file
 while read i; do
+    sum=0
+    for n_attempt in $(seq 1 3); do
         dns=`echo $i | awk -F ',' '{print $1}'`
         ip=`echo $i | awk -F ',' '{print $2}'`
         response=`dig +timeout=1 @$ip $name | grep 'Query time' | awk '{print $4}'`
         if [ -z "$response"  ]; then
             echo $dns $ip "not responding"
+            break;
         else
             printf "%s" $dns
             printf "\t%s\t" $ip
             printf "%s msec\n" $response
 
-            echo $response msec $dns $ip  >>$temp_file
+            sum=$((sum + response))
 
 
         fi
+        if [ "$n_attempt" -eq "3" ]; then
+            echo $((sum/3)) msec $dns $ip  >>$temp_file
+        fi
+    done
 done <dns-list.txt
 
 # Print your fastest DNS

--- a/dns-speed.sh
+++ b/dns-speed.sh
@@ -14,20 +14,20 @@ touch $temp_file
 
 # Test the dns servers listed on the dns-list.txt file
 while read i; do
-    dns=`echo $i | awk -F ',' '{print $1}'`
-    ip=`echo $i | awk -F ',' '{print $2}'`
-    response=`dig +timeout=1 @$ip $name | grep 'Query time' | awk '{print $4}'`
-    if [ -z "$response"  ]; then
-        echo $dns $ip "not responding"
-    else
-        printf "%s" $dns
-        printf "\t%s\t" $ip
-        printf "%s msec\n" $response
+        dns=`echo $i | awk -F ',' '{print $1}'`
+        ip=`echo $i | awk -F ',' '{print $2}'`
+        response=`dig +timeout=1 @$ip $name | grep 'Query time' | awk '{print $4}'`
+        if [ -z "$response"  ]; then
+            echo $dns $ip "not responding"
+        else
+            printf "%s" $dns
+            printf "\t%s\t" $ip
+            printf "%s msec\n" $response
 
-        echo $response msec $dns $ip  >>$temp_file
+            echo $response msec $dns $ip  >>$temp_file
 
 
-    fi
+        fi
 done <dns-list.txt
 
 # Print your fastest DNS


### PR DESCRIPTION
This will take three samples for each DNS server in the list
and it will show the fastest servers based on the average.

This should protect the results from transient delay pikes
as well as transient optimal situations.

The first patch just modifies indentation so the second patch
shows differences properly but otherwise there is no change.

The second patch adds a loop that breaks if any of the samples
fails. If all three samples succeed, the average is calculated and
sent to the temporary file to be used for showing the fastest ones.